### PR TITLE
remove meetings stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@ It:
     - [User Call Logs](https://developers.ringcentral.com/api-reference#Call-Log-loadUserCallLog)
     - [Company Call Logs](https://developers.ringcentral.com/api-reference#Call-Log-loadCompanyCallLog)
     - [SMS/MMS/Voicemal/Fax](https://developers.ringcentral.com/api-reference#SMS-and-MMS-listMessages)
-    - [Meetings](https://developers.ringcentral.com/api-reference#Upcoming-Meetings)
-    
-**NOTE:** The Meetings stream presently only returns Meetings for the user specified by the `username` and `password` in the `config.json` file (see below). To access Meetings for other RingCentral users, you will need to run the tap for this stream with these users credentials specified in the tap config.
 
 ### Quick Start
 
@@ -49,7 +46,6 @@ The following permissions are required:
 - Read Accounts
 - Read Call Log
 - Read Messages
-- Meetings (if using the Meetings stream is enabled)
 
 #### 3. Create the config file.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-ringcentral',
-      version='0.0.1',
+      version='0.0.2',
       description='Singer.io tap for extracting data from the RingCentral API',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',

--- a/tap_ringcentral/schemas/meetings.json
+++ b/tap_ringcentral/schemas/meetings.json
@@ -1,5 +1,8 @@
 {
     "type": "object",
     "properties": {
+        "id": {
+            "type": ["string", "null"]
+        }
     }
 }

--- a/tap_ringcentral/streams/__init__.py
+++ b/tap_ringcentral/streams/__init__.py
@@ -3,14 +3,21 @@ from tap_ringcentral.streams.contacts import ContactsStream
 from tap_ringcentral.streams.call_log import CallLogStream
 from tap_ringcentral.streams.company_call_log import CompanyCallLogStream
 from tap_ringcentral.streams.messages import MessageStream
-from tap_ringcentral.streams.meetings import MeetingStream
+
+# This is disabled because RingCentral's permission model
+# does not permit a user to fetch Meetings for other
+# RingCentral users. It should be re-enabled RingCentral makes
+# these resources accessible in its API
+#
+#from tap_ringcentral.streams.meetings import MeetingStream
+
 
 AVAILABLE_STREAMS = [
     ContactsStream,
     CallLogStream,
     CompanyCallLogStream,
     MessageStream,
-    MeetingStream,
+    #MeetingStream,
 ]
 
 __all__ = [
@@ -18,5 +25,5 @@ __all__ = [
     'CallLogStream',
     'CompanyCallLogStream',
     'MessageStream',
-    'MeetingStream',
+    #'MeetingStream',
 ]


### PR DESCRIPTION
The meetings stream remains unavailable in the RingCentral API, so support for it was removed in this PR.