### PR TITLE
Raise api exception if authentication is not successful

### DIFF
--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -45,7 +45,9 @@ class RingCentralClient:
             headers=headers,
             data=body)
 
-        response.raise_for_status()
+        if response.status_code != 200:
+            raise APIException(response.text)
+
         json = response.json()
         return json['refresh_token'], json['access_token']
 


### PR DESCRIPTION
Use APIException to notify about authentication errors. This will pring response text and will allow to debug authentication errors. Helps to debug issues like #4 