### PR TITLE
reauth when 401 occurs

### DIFF
--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -77,6 +77,11 @@ class RingCentralClient:
             time.sleep(int(timeout))
             raise APIException("Rate limit exceeded")
 
+        elif response.status_code in [401, 403]:
+            # Unauthorized - has the token expired?
+            self.refresh_token, self.access_token = self.get_authorization()
+            raise APIException("Token expired - refetching")
+
         elif response.status_code != 200:
             raise APIException(response.text)
 


### PR DESCRIPTION
If the error code is 401 or 403, regenerate an auth token before trying the request again